### PR TITLE
Problems in XCode 5

### DIFF
--- a/Classes/BSFetchedResultsController.m
+++ b/Classes/BSFetchedResultsController.m
@@ -566,7 +566,7 @@ NSString *const kBSFRCSectionCacheFilteredKey = @"kBSFRCSectionCacheFilteredKey"
 		
 		// Update the various properties
 		[_sortedSectionNames release];
-		_sortedSectionNames = [[NSArray alloc] initWithArray:[[_sectionsByName allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
+		_sortedSectionNames = [[NSMutableArray alloc] initWithArray:[[_sectionsByName allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
 		
 		// Update other ordered things
 		NSMutableArray *indexTitles = [[NSMutableArray alloc] init];
@@ -1292,7 +1292,7 @@ NSString *const kBSFRCSectionCacheFilteredKey = @"kBSFRCSectionCacheFilteredKey"
 	
 	// Update the various properties
 	[_sortedSectionNames release];
-	_sortedSectionNames = [[NSArray alloc] initWithArray:[[_sectionsByName allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
+	_sortedSectionNames = [[NSMutableArray alloc] initWithArray:[[_sectionsByName allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]];
 	
 	// Update other ordered things
 	NSMutableArray *indexTitles = [[NSMutableArray alloc] init];
@@ -1728,7 +1728,7 @@ NSString *const kBSFRCSectionCacheFilteredKey = @"kBSFRCSectionCacheFilteredKey"
 	
 	// Update the various properties
 	[_sortedSectionNames release];
-	_sortedSectionNames = [[NSArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
+	_sortedSectionNames = [[NSMutableArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
 	
 	// Update other ordered things
 	NSMutableArray *indexTitles = [[NSMutableArray alloc] init];
@@ -2024,7 +2024,7 @@ NSString *const kBSFRCSectionCacheFilteredKey = @"kBSFRCSectionCacheFilteredKey"
 	
 	// Update the various properties
 	[_sortedSectionNames release];
-	_sortedSectionNames = [[NSArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
+	_sortedSectionNames = [[NSMutableArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
 	
 	// Update other ordered things
 	NSMutableArray *indexTitles = [[NSMutableArray alloc] init];
@@ -2093,7 +2093,7 @@ NSString *const kBSFRCSectionCacheFilteredKey = @"kBSFRCSectionCacheFilteredKey"
 	
 	// Update the various properties
 	[_sortedSectionNames release];
-	_sortedSectionNames = [[NSArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
+	_sortedSectionNames = [[NSMutableArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
 	
 	// Update other ordered things
 	NSMutableArray *indexTitles = [[NSMutableArray alloc] init];
@@ -2159,7 +2159,7 @@ NSString *const kBSFRCSectionCacheFilteredKey = @"kBSFRCSectionCacheFilteredKey"
 		
 	// Update the various properties
 	[_sortedSectionNames release];
-	_sortedSectionNames = [[NSArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
+	_sortedSectionNames = [[NSMutableArray alloc] initWithArray:[self.sections valueForKeyPath:@"key"]];
 	
 	// Update other ordered things
 	NSMutableArray *indexTitles = [[NSMutableArray alloc] init];

--- a/Classes/BSFetchedResultsController.m
+++ b/Classes/BSFetchedResultsController.m
@@ -1421,7 +1421,7 @@ NSString *const kBSFRCSectionCacheFilteredKey = @"kBSFRCSectionCacheFilteredKey"
 					if (showFilteredObjectsAsGroup) {
 						
 						// The old section has changed
-						if ([oldSection.filtered count] > 0) {
+						if ([oldSection.filteredItems count] > 0) {
 							// We need to update the old section's filtered object container row
 							[updatedObjects addObject:oldSection.filtered];
 						} else {

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -36,14 +36,14 @@
 	self.showFilteredItemGroup = YES;
 	
 	// Create toolbar items
-	UIBarButtonItem *aButton = [[UIBarButtonItem alloc] initWithTitle:@"Toggle Filter" style:UIBarButtonItemStyleBordered target:self action:@selector(toggleFilter:)];
+	UIBarButtonItem *aButton = [[UIBarButtonItem alloc] initWithTitle:@"Toggle Filter" style:UIBarButtonItemStylePlain target:self action:@selector(toggleFilter:)];
 	self.toggleFilter = aButton;
 	UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
-	UIBarButtonItem *toggleShowingFilteredGroup = [[UIBarButtonItem alloc] initWithTitle:@"Show/Hide Filtered Group" style:UIBarButtonItemStyleBordered target:self action:@selector(toggleShowingFilteredItemsGroup:)];
+	UIBarButtonItem *toggleShowingFilteredGroup = [[UIBarButtonItem alloc] initWithTitle:@"Show/Hide Filtered Group" style:UIBarButtonItemStylePlain target:self action:@selector(toggleShowingFilteredItemsGroup:)];
 	if (self.showFilteredItemGroup) {
 		[toggleShowingFilteredGroup setStyle:UIBarButtonItemStyleDone];
 	} else {
-		[toggleShowingFilteredGroup setStyle:UIBarButtonItemStyleBordered];
+		[toggleShowingFilteredGroup setStyle:UIBarButtonItemStylePlain];
 	}
 	toggleShowingFilteredGroup.enabled = self.enableFilter; 
 	self.showOrHideFilteredGroup = toggleShowingFilteredGroup;
@@ -197,7 +197,7 @@
 	if (enableFilter) {
 		[self.toggleFilter setStyle:UIBarButtonItemStyleDone];
 	} else {
-		[self.toggleFilter setStyle:UIBarButtonItemStyleBordered];
+		[self.toggleFilter setStyle:UIBarButtonItemStylePlain];
 	}
 	self.showOrHideFilteredGroup.enabled = self.enableFilter;
 }
@@ -209,7 +209,7 @@
 	if (self.showFilteredItemGroup) {
 		[self.showOrHideFilteredGroup setStyle:UIBarButtonItemStyleDone];
 	} else {
-		[self.showOrHideFilteredGroup setStyle:UIBarButtonItemStyleBordered];
+		[self.showOrHideFilteredGroup setStyle:UIBarButtonItemStylePlain];
 	}
 }
 
@@ -422,6 +422,11 @@
             
         case NSFetchedResultsChangeDelete:
             [self.tableView deleteSections:[NSIndexSet indexSetWithIndex:sectionIndex] withRowAnimation:UITableViewRowAnimationFade];
+            break;
+
+        case NSFetchedResultsChangeMove:
+            break;
+        case NSFetchedResultsChangeUpdate:
             break;
     }
 }

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -355,7 +355,7 @@
 	
 	
 	// Add a post fetch sort comparator
-	fetchedResultsController.postFetchComparator = ^(id a, id b) {
+	fetchedResultsController.postFetchComparator = ^NSComparisonResult(id a, id b) {
 		// if the city is a capital, it always comes before non-capitals
 		NSComparisonResult result = [((City *)a).isCapital compare:((City *)b).isCapital];		
 		if (result != NSOrderedSame)
@@ -374,7 +374,7 @@
 //	fetchedResultsController.postFetchFilterPredicate = [NSPredicate predicateWithFormat:@"population > %d", 100000];
 	
 	// Add a post fetch filter test
-	fetchedResultsController.postFetchFilterTest = ^(id obj, BOOL *stop) {
+	fetchedResultsController.postFetchFilterTest = ^BOOL(id obj, BOOL *stop) {
 		if ([(City *)obj populationValue] > 100000) {
 			return YES;
 		} else {


### PR DESCRIPTION
When updating the code with XCode 5 - the compiler is finding a few errors - some are just warnings, it appears a few are real errors

// The old section has changed
if ([oldSection.filtered count] > 0) {
// We need to update the old section's filtered object container row
  [updatedObjects addObject:oldSection.filtered];
}

should it be using filtered.items ?  as filtered doesn't seem to directly implement count method.

if ([oldSection.filtered.items count] > 0) {
// We need to update the old section's filtered object container row
  [updatedObjects addObject:oldSection.filtered];
}


							
